### PR TITLE
Set column width correctly for strings with newlines

### DIFF
--- a/R/viz_forest.R
+++ b/R/viz_forest.R
@@ -487,8 +487,10 @@ viz_forest <- function(x, group = NULL, type = "standard", variant = "classic", 
         tbl_titles <- names(tbl)
       }
       v <- df_to_vector(tbl)
-
-      area_per_column <- cumsum(c(1, apply(rbind(tbl_titles, tbl), 2, function(x) max(round(max(nchar(x, keepNA = FALSE))/100, 2),  0.03))))
+      
+      nchar2<-function(x){unlist(sapply(strsplit(x,"\n"),nchar, keepNA = FALSE))}
+      
+      area_per_column <- cumsum(c(1, apply(rbind(tbl_titles, tbl), 2, function(x) max(round(max(nchar2(x))/100, 2),  0.03))))
       x_values <- area_per_column[1:ncol(tbl)]
       x_limit <- range(area_per_column)
 

--- a/R/viz_forest.R
+++ b/R/viz_forest.R
@@ -488,7 +488,7 @@ viz_forest <- function(x, group = NULL, type = "standard", variant = "classic", 
       }
       v <- df_to_vector(tbl)
       
-      nchar2<-function(x){unlist(sapply(strsplit(x,"\n"),nchar, keepNA = FALSE))}
+      nchar2<-function(x){unlist(sapply(strsplit(x,"\n"), function(x) max(nchar(x, keepNA = FALSE))))}
       
       area_per_column <- cumsum(c(1, apply(rbind(tbl_titles, tbl), 2, function(x) max(round(max(nchar2(x))/100, 2),  0.03))))
       x_values <- area_per_column[1:ncol(tbl)]


### PR DESCRIPTION
Set column width correctly in the summary table in viz_forest() for strings with newlines

Previously it would correctly render the newline but the column width would be enough for all the text on a single line. This fixes that.

P.S. Thanks for the great package Michael!